### PR TITLE
Fix updater URL scheme

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ if (process.platform !== 'darwin') {
 }*/
 
 // New autoUpdater setup using Hazel
-const server = 'https//update.frostworld.studio'
+const server = 'https://update.frostworld.studio'
 const url = `${server}/update/${process.platform}/${app.getVersion()}`
 
 autoUpdater.setFeedURL({


### PR DESCRIPTION
## Summary
- fix typo in auto updater URL to include https scheme

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689649dec3508332b41c0913459910d4